### PR TITLE
Birden fazla konteyner oluşturmak için deploy özelliğini kullanın

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -37,10 +37,8 @@ services:
       timeout: 5s
       retries: 5
 
-  dbreader-app-1:
-    # build: .
-    container_name: dbreader-app-1
-    hostname: dbreader-app-1
+  dbreader-app:
+    hostname: dbreader-app
     image: openjdk:17-jdk-slim
     command: ['java', '-jar', '/app/db-reader-1.0.0.jar']
     volumes:
@@ -55,42 +53,8 @@ services:
     networks:
       - dbreader-network
     restart: unless-stopped
-
-  dbreader-app-2:
-    image: openjdk:17-jdk-slim
-    command: ['java', '-jar', '/app/db-reader-1.0.0.jar']
-    volumes:
-      - ${WORKSPACE_PATH_ON_HOST}/target:/app
-    container_name: dbreader-app-2
-    hostname: dbreader-app-2
-    environment:
-      - APP_PROCESSING_INTERVAL=${PROCESSING_INTERVAL:-60000} # Default 1 minute
-    depends_on:
-      zookeeper:
-        condition: service_healthy
-      mysql:
-        condition: service_healthy
-    networks:
-      - dbreader-network
-    restart: unless-stopped
-
-  dbreader-app-3:
-    image: openjdk:17-jdk-slim
-    command: ['java', '-jar', '/app/db-reader-1.0.0.jar']
-    volumes:
-      - ${WORKSPACE_PATH_ON_HOST}/target:/app
-    container_name: dbreader-app-3
-    hostname: dbreader-app-3
-    environment:
-      - APP_PROCESSING_INTERVAL=${PROCESSING_INTERVAL:-60000} # Default 1 minute
-    depends_on:
-      zookeeper:
-        condition: service_healthy
-      mysql:
-        condition: service_healthy
-    networks:
-      - dbreader-network
-    restart: unless-stopped
+    deploy:
+      replicas: 3
 
 volumes:
   mysql_data:


### PR DESCRIPTION
Docker Compose içinde `deploy.replicas` kullanarak K8s’teki Deployment’ın eşdeğerini oluşturabiliyoruz. Bu örnekte hem çoğaltma (replica) sayısını tanımlayıp hem de tüm kopyalar için ortak bir hostname belirlemek mümkün:

```yaml
dbreader-app:
  hostname: dbreader-app
  deploy:
    replicas: 3
````

Yukarıdaki konfigürasyonla ayağa kalkan servise `nslookup` çektiğimizde tek bir hostname altında birden fazla IP döndüğünü görebiliriz:

```bash
root@dbreader-app:/# nslookup dbreader-app
Server:         127.0.0.11
Address:        127.0.0.11#53

Non-authoritative answer:
Name:   dbreader-app
Address: 172.18.0.4
Name:   dbreader-app
Address: 172.18.0.5
Name:   dbreader-app
Address: 172.18.0.6
```

Bu kullanımda `container_name` belirtmemize izin verilmiyor; Compose konteyner adlarını otomatik olarak `<compose-name>-<service-name>-<index>` şablonuna göre oluşturuyor. Bizim örnekte oluşan adlar şöyle:

```bash
root@dbreader-app:/# nslookup zookeeper-java-dbreader-app-1
...
Address: 172.18.0.5

root@dbreader-app:/# nslookup zookeeper-java-dbreader-app-2
...
Address: 172.18.0.4

root@dbreader-app:/# nslookup zookeeper-java-dbreader-app-3
...
Address: 172.18.0.6
```

> **Ek**
> Replika sayısını dinamik olarak artırmak veya azaltmak için şu komutu kullanabilirsiniz:

```bash
docker compose -f docker-compose-test.yml scale dbreader-app=4
```

Özetle, `deploy.replicas` ile skala ederken sabit bir hostname tanımlayabiliyoruz; ancak her replikanın özgün adını (`container_name`) manuel vermek mümkün olmuyor.

